### PR TITLE
Update README files for document address

### DIFF
--- a/examples/blog-with-retypeset-and-contentful/README.md
+++ b/examples/blog-with-retypeset-and-contentful/README.md
@@ -19,7 +19,7 @@ More Templates: [EdgeOne Pages](https://edgeone.ai/pages/templates)
 - Step4 Execute the import command: `contentful space import --content-file contentful-blog-model.json --space-id  ${your Contentful space id}`
 - Step5 Copy the Contentful Space Id and Contentful Delivery API token for later use
 
-> For more Contentful integration documentation:https://edgeone.ai/document/178178425272651776
+> For more Contentful integration documentation: [https://pages.edgeone.ai/document/contentful-integration](https://pages.edgeone.ai/document/contentful-integration)
 
 ### Using This Template
 

--- a/examples/blog-with-retypeset-and-contentful/README_zh-CN.md
+++ b/examples/blog-with-retypeset-and-contentful/README_zh-CN.md
@@ -17,7 +17,7 @@
 - Step4 执行导入命令：`contentful space import --content-file contentful-blog-model.json --space-id ${你的 Contentful space id}`
 - Step5 复制 Contentful Space Id 和 Contentful Delivery API token 备用
 
-> 更多 Contentful 集成参考文档:https://edgeone.cloud.tencent.com/pages/document/178968240027983872
+> 更多 Contentful 集成参考文档: [https://pages.edgeone.ai/zh/document/contentful-integration](https://pages.edgeone.ai/zh/document/contentful-integration)
 
 ### 使用本模板
 

--- a/examples/deepseek-r1-edge/README.md
+++ b/examples/deepseek-r1-edge/README.md
@@ -2,7 +2,7 @@
 
 Utilize DeepSeek R1 in edge functions with integrated web search capabilities.
 
-The search functionality utilizes [searxng](https://github.com/searxng/searxng) and is encapsulated via [EdgeOne Pages functions](https://edgeone.ai/document/162227908259442688).
+The search functionality utilizes [searxng](https://github.com/searxng/searxng) and is encapsulated via [EdgeOne Pages functions](https://pages.edgeone.ai/document/pages-functions-overview).
 
 After deployment, the interface ensures a consistent experience with OpenAI and seamlessly integrates with other third-party tools.
 

--- a/examples/deepseek-r1-edge/README_zh-CN.md
+++ b/examples/deepseek-r1-edge/README_zh-CN.md
@@ -2,7 +2,7 @@
 
 在边缘函数中使用 DeepSeek R1，同时支持网络搜索功能。
 
-搜索功能使用 [searxng](https://github.com/searxng/searxng)，并通过 [EdgeOne Pages 函数](https://edgeone.ai/document/162227908259442688) 进行封装。
+搜索功能使用 [searxng](https://github.com/searxng/searxng)，并通过 [EdgeOne Pages 函数](https://pages.edgeone.ai/zh/document/pages-functions-overview) 进行封装。
 
 部署后获得与 OpenAI 体验一致的接口，能够与其他第三方工具无缝集成。
 

--- a/examples/mcp-geo/README.md
+++ b/examples/mcp-geo/README.md
@@ -1,4 +1,4 @@
-# MCP with Pages Functions ：Geo Location Demo 
+# MCP with Pages Functions ：Geo Location Demo
 
 This project demonstrates how to use EdgeOne Pages Functions to retrieve user geolocation information and integrate it with large language models through MCP (Model Context Protocol).
 
@@ -18,18 +18,18 @@ More Templates: [EdgeOne Pages](https://edgeone.ai/pages/templates)
 
 The project includes an EdgeOne Pages Function that retrieves user geolocation information:
 
-* Uses the EdgeOne request context to access geolocation data
-* Returns location information in a JSON format
-* Located in `functions/get_geo.ts`
+- Uses the EdgeOne request context to access geolocation data
+- Returns location information in a JSON format
+- Located in `functions/get_geo.ts`
 
 ### 2. MCP Server Integration
 
 The MCP server component provides an interface for large language models to access geolocation data:
 
-* Implements the Model Context Protocol (MCP)
-* Exposes a `get_geolocation` tool that can be used by AI models
-* Uses the EdgeOne Pages Function to fetch geolocation data
-* Located in `mcp-server/index.ts`
+- Implements the Model Context Protocol (MCP)
+- Exposes a `get_geolocation` tool that can be used by AI models
+- Uses the EdgeOne Pages Function to fetch geolocation data
+- Located in `mcp-server/index.ts`
 
 ## MCP Configuration
 
@@ -48,6 +48,6 @@ To use the MCP server with large language models, add the following configuratio
 
 ## Learn More
 
-* [EdgeOne Pages](https://edgeone.ai/products/pages)
-* [EdgeOne Pages Functions documentation](https://edgeone.ai/document/162227908259442688)
-* [Model Context Protocol (MCP)](https://modelcontextprotocol.github.io) - Learn about integrating AI models with external tools and services
+- [EdgeOne Pages](https://edgeone.ai/products/pages)
+- [EdgeOne Pages Functions documentation](https://pages.edgeone.ai/document/pages-functions-overview)
+- [Model Context Protocol (MCP)](https://modelcontextprotocol.github.io) - Learn about integrating AI models with external tools and services

--- a/examples/mcp-geo/README_zh-CN.md
+++ b/examples/mcp-geo/README_zh-CN.md
@@ -16,18 +16,18 @@
 
 该项目包含一个 EdgeOne Pages 函数，用于获取用户地理位置信息：
 
-* 使用 EdgeOne 请求上下文访问地理位置数据
-* 以 JSON 格式返回位置信息
-* 位于 `functions/get_geo.ts`
+- 使用 EdgeOne 请求上下文访问地理位置数据
+- 以 JSON 格式返回位置信息
+- 位于 `functions/get_geo.ts`
 
 ### 2. MCP 服务器集成
 
 MCP 服务器组件为大型语言模型提供了访问地理位置数据的接口：
 
-* 实现了模型上下文协议（MCP）
-* 提供了一个可被 AI 模型使用的 `get_geolocation` 工具
-* 使用 EdgeOne Pages 函数获取地理位置数据
-* 位于 `mcp-server/index.ts`
+- 实现了模型上下文协议（MCP）
+- 提供了一个可被 AI 模型使用的 `get_geolocation` 工具
+- 使用 EdgeOne Pages 函数获取地理位置数据
+- 位于 `mcp-server/index.ts`
 
 ## MCP 配置
 
@@ -46,6 +46,6 @@ MCP 服务器组件为大型语言模型提供了访问地理位置数据的接�
 
 ## 了解更多
 
-* [EdgeOne Pages](https://edgeone.ai/products/pages)
-* [EdgeOne Pages 函数文档](https://edgeone.ai/document/162227908259442688)
-* [模型上下文协议 (MCP)](https://modelcontextprotocol.github.io) - 了解如何将 AI 模型与外部工具和服务集成
+- [EdgeOne Pages](https://edgeone.ai/products/pages)
+- [EdgeOne Pages 函数文档](https://pages.edgeone.ai/zh/document/pages-functions-overview)
+- [模型上下文协议 (MCP)](https://modelcontextprotocol.github.io) - 了解如何将 AI 模型与外部工具和服务集成

--- a/examples/mcp-on-edge/README.md
+++ b/examples/mcp-on-edge/README.md
@@ -74,5 +74,5 @@ After starting, visit [http://localhost:3000](http://localhost:3000) in your bro
 Learn more about related technologies:
 
 - [Next.js Documentation](https://nextjs.org/docs) - Next.js framework features and API
-- [EdgeOne Pages Functions Documentation](https://edgeone.ai/document/162227908259442688s) - Detailed explanation of EdgeOne serverless functions
+- [EdgeOne Pages Functions Documentation](https://pages.edgeone.ai/document/pages-functions-overview) - Detailed explanation of EdgeOne serverless functions
 - [Model Context Protocol (MCP)](https://modelcontextprotocol.io/specification/2025-03-26/changelog) - Implemented based on the 2025-03-26 version of Streamable HTTP transport

--- a/examples/mcp-on-edge/README_zh-CN.md
+++ b/examples/mcp-on-edge/README_zh-CN.md
@@ -76,5 +76,5 @@ npm run dev
 了解更多相关技术：
 
 - [Next.js 文档](https://nextjs.org/docs) - Next.js 框架特性与 API
-- [EdgeOne Pages 函数文档](https://edgeone.ai/document/162227908259442688s) - EdgeOne 无服务器函数详解
+- [EdgeOne Pages 函数文档](https://pages.edgeone.ai/zh/document/pages-functions-overview) - EdgeOne 无服务器函数详解
 - [模型上下文协议 (MCP)](https://modelcontextprotocol.io/specification/2025-03-26/changelog) - 基于 2025-03-26 版本实现的 Streamable HTTP transport

--- a/examples/mcp-open/README.md
+++ b/examples/mcp-open/README.md
@@ -10,10 +10,10 @@ EdgeOne Pages MCP server lets AI coding assistants deploy HTML directly to EdgeO
 
 EdgeOne Pages is perfect for MCP services thanks to its serverless architecture. With code running at edge nodes worldwide, you can:
 
-* Deploy AI-generated HTML instantly
-* Get public URLs with minimal latency
-* Scale automatically as needed
-* Skip the server management headaches
+- Deploy AI-generated HTML instantly
+- Get public URLs with minimal latency
+- Scale automatically as needed
+- Skip the server management headaches
 
 ## Key Features
 
@@ -45,9 +45,9 @@ Here's how to set it up in Cursor:
 
 1. Go to Settings → MCP
 2. Add a new MCP Server with these details:
-   * Name: edgeone-pages-mcp-server
-   * Type: command
-   * Command: npx edgeone-pages-mcp
+   - Name: edgeone-pages-mcp-server
+   - Type: command
+   - Command: npx edgeone-pages-mcp
 
 ![](https://write-document-release-1258344699.cos.ap-guangzhou.myqcloud.com/100026466949%2F3113c4ad09f211f0a6d15254007c27c5.png)
 
@@ -68,12 +68,13 @@ This MCP service plugs into EdgeOne Pages Functions to handle HTML deployment:
 
 1. **EdgeOne Pages Functions** runs your JavaScript/TypeScript at the edge.
 
-2. **Behind the Scenes:** 
+2. **Behind the Scenes:**
+
    - Stores HTML in EdgeOne Pages KV
    - Generates unique public URLs
    - Handles errors gracefully
 
-3. **The Process:** 
+3. **The Process:**
    - Send HTML via the `deploy_html` tool
    - EdgeOne Pages API generates a base URL
    - Content deploys to EdgeOne KV
@@ -95,4 +96,4 @@ Get started by signing up at [EdgeOne Pages](https://edgeone.ai/products/pages) 
 
 ## Learn More
 
-For details, check out the [EdgeOne Pages Functions documentation](https://edgeone.ai/document/162227908259442688) and [EdgeOne Pages KV Storage Guide](https://edgeone.ai/document/162227803822321664).
+For details, check out the [EdgeOne Pages Functions documentation](https://pages.edgeone.ai/document/pages-functions-overview) and [EdgeOne Pages KV Storage Guide](https://pages.edgeone.ai/document/kv-storage).

--- a/examples/mcp-open/README_zh-CN.md
+++ b/examples/mcp-open/README_zh-CN.md
@@ -77,6 +77,6 @@ EdgeOne Pages 为现代 Web 开发提供全套解决方案:
 
 ## 了解更多
 
-- [EdgeOne Pages 产品介绍](https://edgeone.ai/products/pages)
-- [EdgeOne Pages Functions 开发文档](https://edgeone.ai/document/162227908259442688)
-- [EdgeOne Pages KV 存储指南](https://edgeone.ai/document/162227803822321664)
+- [EdgeOne Pages 产品介绍](https://pages.edgeone.ai/zh/document/product-introduction)
+- [EdgeOne Pages Functions 开发文档](https://pages.edgeone.ai/zh/document/pages-functions-overview)
+- [EdgeOne Pages KV 存储指南](https://pages.edgeone.ai/zh/document/kv-storage)

--- a/examples/portfolio-with-sanity/README.md
+++ b/examples/portfolio-with-sanity/README.md
@@ -22,7 +22,7 @@ NEXT_PUBLIC_SANITY_DATASET=${your sanity dataset}
 ```
 
 ![](https://cloudcache.tencent-cloud.com/qcloud/ui/static/static_source_business/98699d3e-dacd-4317-b087-e6e3b8265997.png)
-Sanity integration guide:https://edgeone.ai/document/178179132824436736?product=edgedeveloperplatform
+Sanity integration guide: [https://pages.edgeone.ai/document/sanity-integration](https://pages.edgeone.ai/document/sanity-integration)
 
 ## Getting Started
 

--- a/examples/portfolio-with-sanity/README_zh-CN.md
+++ b/examples/portfolio-with-sanity/README_zh-CN.md
@@ -25,7 +25,7 @@ NEXT_PUBLIC_SANITY_DATASET=${你的 sanity 数据集}
 ```
 
 ![](https://cloudcache.tencent-cloud.com/qcloud/ui/static/static_source_business/752893cb-caf0-4414-902a-8380c6ba243a.png)
-Sanity 集成指南：https://edgeone.cloud.tencent.com/pages/document/178968125217869824
+Sanity 集成指南：[https://pages.edgeone.ai/document/sanity-integration](https://pages.edgeone.ai/document/sanity-integration)
 
 ## 本地开发
 


### PR DESCRIPTION
The documentation URL for Pages in the template project needs to be updated, as the main Pages documentation has been migrated to its new, standalone website.